### PR TITLE
Add instrumentation capabilities into the throttler

### DIFF
--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -23,7 +23,7 @@ module Freno
       instrument(:called) do
         waited = 0
 
-        while true do
+        while true do # rubocop:disable Lint/LiteralInCondition
           if all_stores_caught_up?(context)
             instrument(:succeeded, waited: waited)
             return yield

--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -1,26 +1,42 @@
 require "freno/throttler/version"
+require "freno/throttler/instrumenter"
 require "freno/throttler/errors"
 
 module Freno
   class Throttler
 
-    attr_accessor :client, :mapper, :app, :wait_seconds, :max_wait_seconds, :options
+    attr_accessor :client, :app, :mapper, :instrumenter, :wait_seconds, :max_wait_seconds, :options
 
-    def initialize(client, app, mapper, wait_seconds: 0.5, max_wait_seconds: 10, options: {})
+    def initialize(client, app, mapper, instrumenter: Instrumenter::Noop,  wait_seconds: 0.5, max_wait_seconds: 10, options: {})
       @client           = client
       @app              = app
       @mapper           = mapper
+      @instrumenter     = instrumenter
       @wait_seconds     = wait_seconds
       @max_wait_seconds = max_wait_seconds
       @options          = options
+
+      yield self if block_given?
     end
 
     def throttle(context: nil)
-      waited = 0
-      while true do
-        return yield if all_stores_caught_up?(context)
-        waited += wait
-        raise WaitedTooLong if waited > max_wait_seconds
+      instrument(:called) do
+        waited = 0
+
+        while true do
+          if all_stores_caught_up?(context)
+            instrument(:succeeded, waited: waited)
+            return yield
+          end
+
+          waited += wait
+          instrument(:waited, waited: waited, max: max_wait_seconds)
+
+          if waited > max_wait_seconds
+            instrument(:waited_too_long, waited: waited, max: max_wait_seconds)
+            raise WaitedTooLong
+          end
+        end
       end
     end
 
@@ -33,11 +49,16 @@ module Freno
         client.check?(app: app, store_name: store_name)
       end
     rescue Freno::Error => e
+      instrument(:freno_errored, error: e)
       raise ClientError.new(e)
     end
 
     def wait
       sleep wait_seconds
+    end
+
+    def instrument(event_name, payload = {}, &block)
+      instrumenter.instrument("throttler.#{event_name}", &block)
     end
   end
 end

--- a/lib/freno/throttler/instrumenter.rb
+++ b/lib/freno/throttler/instrumenter.rb
@@ -1,0 +1,24 @@
+module Freno
+  class Throttler
+    module Instrumenter
+
+      # Any instrumenter is an object that responds to
+      # `instrument(event_name, payload = {})` to receive events from the
+      # throttler.
+      #
+      # As an example, one could provide ActiveSupport::Notifications as an
+      # instrumenter to publish events in the ActiveSupport::Notifications
+      # system, that can be subcribed somewherelese in rails applications.
+      #
+      # The Noop instrumenter does nothing but yielding the control to the block
+      # given if it is provided, and it's used as the default `:instrumenter`
+      # for a throttler instance.
+      #
+      class Noop
+        def self.instrument(event_name, payload = {})
+          yield payload if block_given?
+        end
+      end
+    end
+  end
+end

--- a/test/freno/throttler_test.rb
+++ b/test/freno/throttler_test.rb
@@ -8,11 +8,17 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
 
   def test_throttle_runs_the_block_when_all_stores_have_caught_up
     block_called = false
-    throttler = Freno::Throttler.new(client, :github, ->(context) {[]})
+    throttler = Freno::Throttler.new(client, :github, ->(context) {[]}, instrumenter: MemoryInstrumenter.new)
     throttler.throttle do
       block_called = true
     end
     assert block_called, "block should have been called"
+
+    assert_equal 1, throttler.instrumenter.count("throttler.called")
+    assert_equal 1, throttler.instrumenter.count("throttler.succeeded")
+    assert_equal 0, throttler.instrumenter.count("throttler.waited")
+    assert_equal 0, throttler.instrumenter.count("throttler.waited_too_long")
+    assert_equal 0, throttler.instrumenter.count("throttler.freno_errored")
   end
 
   def test_sleeps_when_a_check_fails_and_then_calls_the_block
@@ -21,7 +27,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = client
     stub.expects(:check?).times(2).with(app: :github, store_name: :mysqla).returns(false).then.returns(true)
 
-    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]})
+    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]}, instrumenter: MemoryInstrumenter.new)
     throttler.expects(:wait).once.returns(0.1)
 
     throttler.throttle do
@@ -29,6 +35,12 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     end
 
     assert block_called, "block should have been called"
+
+    assert_equal 1, throttler.instrumenter.count("throttler.called")
+    assert_equal 1, throttler.instrumenter.count("throttler.succeeded")
+    assert_equal 1, throttler.instrumenter.count("throttler.waited")
+    assert_equal 0, throttler.instrumenter.count("throttler.waited_too_long")
+    assert_equal 0, throttler.instrumenter.count("throttler.freno_errored")
   end
 
   def test_raises_waited_too_long_if_freno_checks_failed_consistenly
@@ -37,7 +49,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = client
     stub.expects(:check?).at_least(3).with(app: :github, store_name: :mysqla).returns(false)
 
-    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]}, wait_seconds: 0.1, max_wait_seconds: 0.3)
+    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]}, instrumenter: MemoryInstrumenter.new, wait_seconds: 0.1, max_wait_seconds: 0.3)
     throttler.expects(:wait).times(3).returns(0.1)
 
     assert_raises(Freno::Throttler::WaitedTooLong) do
@@ -47,6 +59,12 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     end
 
     refute block_called, "block should not have been called"
+
+    assert_equal 1, throttler.instrumenter.count("throttler.called")
+    assert_equal 0, throttler.instrumenter.count("throttler.succeeded")
+    assert_equal 3, throttler.instrumenter.count("throttler.waited")
+    assert_equal 1, throttler.instrumenter.count("throttler.waited_too_long")
+    assert_equal 0, throttler.instrumenter.count("throttler.freno_errored")
   end
 
   def test_raises_a_specific_error_in_case_freno_itself_errored
@@ -55,7 +73,7 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     stub = client
     stub.expects(:check?).raises(Freno::Error)
 
-    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]}, wait_seconds: 0.1, max_wait_seconds: 0.3)
+    throttler = Freno::Throttler.new(stub, :github, ->(context) {[:mysqla]}, instrumenter: MemoryInstrumenter.new, wait_seconds: 0.1, max_wait_seconds: 0.3)
     throttler.expects(:wait).never
 
     assert_raises(Freno::Throttler::ClientError) do
@@ -65,5 +83,11 @@ class Freno::ThrottlerTest < Freno::Throttler::Test
     end
 
     refute block_called, "block should not have been called"
+
+    assert_equal 1, throttler.instrumenter.count("throttler.called")
+    assert_equal 0, throttler.instrumenter.count("throttler.succeeded")
+    assert_equal 0, throttler.instrumenter.count("throttler.waited")
+    assert_equal 0, throttler.instrumenter.count("throttler.waited_too_long")
+    assert_equal 1, throttler.instrumenter.count("throttler.freno_errored")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,4 +11,24 @@ class Freno::Throttler::Test < Minitest::Test
       freno.default_store_type = :mysql
     end
   end
+
+  class MemoryInstrumenter
+    def initialize
+      @events = {}
+    end
+
+    def instrument(event, payload = {})
+      @events[event] ||= []
+      @events[event] <<  payload
+      yield payload if block_given?
+    end
+
+    def events_for(event)
+      @events[event]
+    end
+
+    def count(event)
+      @events[event] ? @events[event].count : 0
+    end
+  end
 end


### PR DESCRIPTION
This PR adds instrumentation capabilities into the throttler, so we can plug in components such as `ActiveSupport::Notifications` (or custom ones) that allow us to introduce cross-cutting concerns such as logging or metrics reporting.

We will use this within github to report metrics to Datadog.