### PR TITLE
Implement support for circuit breakers

### DIFF
--- a/lib/freno/throttler.rb
+++ b/lib/freno/throttler.rb
@@ -17,7 +17,7 @@ module Freno
   # Let's use the following throttler, which uses Mapper::Identity implicitly.
   # (see #initialze docs)
   #
-  # ```ruby
+  # ```
   # throttler = Throttler.new(client: freno_client, app: :my_app)
   # data.find_in_batches do |batch|
   #   throttler.throttle([:mysqla, :mysqlb]) do
@@ -50,12 +50,12 @@ module Freno
     #
     # Also, you can optionally provide the following named arguments:
     #
-    #  - `:mapper`: An object that responds to call(context) and returns a
-    #     Enumerable of the store names for which we need to wait for
-    #     replication delay. By default this is the IdentityMapper, which will
+    #  - `:mapper`: An object that responds to `call(context)` and returns a
+    #     `Enumerable` of the store names for which we need to wait for
+    #     replication delay. By default this is the `IdentityMapper`, which will
     #     check the stores given as context.
     #
-    #     For example, if the `thorttler` object used the default mapper:
+    #     For example, if the `throttler` object used the default mapper:
     #
     #      ```
     #      throttler.throttle(:mysqlc) do
@@ -65,7 +65,7 @@ module Freno
     #
     #  - `:instrumenter`: An object that responds to
     #     `instrument(event_name, context = {}, &block)` that can be used to
-    #     add cross-cutting concerns like logging, or stats to the throttler.
+    #     add cross-cutting concerns like logging or stats to the throttler.
     #
     #     By default, the instrumenter is `Intrumenter::Noop`, which does
     #     nothing but yielding the block it receives.

--- a/lib/freno/throttler/circuit_breaker.rb
+++ b/lib/freno/throttler/circuit_breaker.rb
@@ -1,0 +1,39 @@
+module Freno
+  class Throttler
+
+    # An CircuitBreaker is the entry point of the pattern with same name.
+    # (see https://martinfowler.com/bliki/CircuitBreaker.html)
+    #
+    # Clients that use circuit brakers to add resiliency to their processes
+    # send `failure` or `sucess` messages to the CircuitBreaker depending on the
+    # results of the last requests made.
+    #
+    # With that information, the circuit breaker determines whether or not to
+    # allow the next request (`allow_request?`). A circuit is said to be open
+    # when the next request is not allowed; and it's said to be closed when the
+    # next request is allowed.
+    #
+    module CircuitBreaker
+
+      # The Noop circuit breaker is the `:circuit_breaker` used by default in
+      # the Throttler
+      #
+      # It always allows requests, and does nothing when given `success` or
+      # `failure` messages. For that reason it doesn't provide any resiliency
+      # guarantee.
+      #
+      # See https://github.com/jnunemaker/resilient for a real ruby implementation
+      # of the CircuitBreaker pattern.
+      #
+      class Noop
+        def self.allow_request?
+          true
+        end
+
+        def self.success; end
+
+        def self.failure; end
+      end
+    end
+  end
+end

--- a/lib/freno/throttler/errors.rb
+++ b/lib/freno/throttler/errors.rb
@@ -14,6 +14,9 @@ module Freno
       end
     end
 
+    # Raised if the circuit breaker is open and didn't allow latest request
+    class CircuitOpen < Error; end
+
     # Raised if the freno client errored.
     class ClientError < Error; end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,4 +31,20 @@ class Freno::Throttler::Test < Minitest::Test
       @events[event] ? @events[event].count : 0
     end
   end
+
+  class SingleFailureAllowedCircuitBreaker
+    def initialize
+      @failed_once = false
+    end
+
+    def allow_request?
+      !@failed_once
+    end
+
+    def success; end
+
+    def failure
+      @failed_once = true
+    end
+  end
 end


### PR DESCRIPTION
From [the second commit](https://github.com/github/freno-throttler/commit/65f0a4a77465dfa213bbb37123966bf0f2a124fe) message: 

```
Extends the throttler with minimal resiliency capabilities. The
throttler now can receive a `:circuit_breaker` object responding to
`success`, `failure`, and `allow_request?`.

When an error occurs in the throttler, this sends
the `failure` message to the circuit breaker object;
if it succeeds, it sends the `success` message.

With the information provided, the circuit breaker decides whether or
not to `allow_request?` the next time `throttle` checks freno, 
raising a `CircuitOpen` error in case it does not allow the next call.

By default `Throttler::CircuitBreaker::Noop` is used in the throttler,
which does nothing and works as if no circuit breaker existed.
```